### PR TITLE
Replace Docker `node` image version

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.19.0-alpine
+FROM node:18-alpine
 
 WORKDIR /app
 

--- a/api/Dockerfile.compose
+++ b/api/Dockerfile.compose
@@ -1,4 +1,4 @@
-FROM node:18.19.0-alpine
+FROM node:18-alpine
 WORKDIR /opt/node_app/app
 
 COPY package.json package-lock.json ./

--- a/api/Dockerfile.dev
+++ b/api/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:18.19.0-alpine as builder
+FROM node:18-alpine as builder
 
 COPY package.json package-lock.json ./
 COPY tsconfig.json ./

--- a/api/package.json
+++ b/api/package.json
@@ -86,6 +86,6 @@
     "winston-daily-rotate-file": "^4.5.0"
   },
   "engines": {
-    "node": "18.19.0"
+    "node": "18"
   }
 }

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.19.0 AS builder
+FROM node:18 AS builder
 RUN curl -o- -L https://yarnpkg.com/install.sh | bash
 
 # set working directory


### PR DESCRIPTION
Replace fully qualified `node` version of image (`node:18.19.0-alpine`) with latest v18 image `node:18-alpine`

note: still resolves to `node 18.19.0`